### PR TITLE
Add the Displaying of Tags to the Item Interface

### DIFF
--- a/item/item.html
+++ b/item/item.html
@@ -87,6 +87,9 @@
                     </p>
 
                     <p class="overview hide"></p>
+                    
+                    <div class="tags hide">
+                    </div>
 
                     <div class="trackList" is="emby-itemscontainer">
 

--- a/item/item.html
+++ b/item/item.html
@@ -88,8 +88,8 @@
 
                     <p class="overview hide"></p>
                     
-                    <div class="tags hide">
-                    </div>
+                    <p class="tags hide">
+                    </p>
 
                     <div class="trackList" is="emby-itemscontainer">
 

--- a/item/item.js
+++ b/item/item.js
@@ -390,6 +390,22 @@ define(['itemContextMenu', 'loading', './../skininfo', 'datetime', 'playbackMana
                 genresElem.classList.remove('hide');
                 genresElem.innerHTML = genresHtml;
             }
+            
+            var tags = item.Tags || [];
+            var tagsHtml = tags.map(function (i) {
+
+                return i;
+
+            }).join('<span class="bulletSeparator">&bull;</span>');
+
+            var tagsElem = view.querySelector('.tags');
+
+            if (!tagsHtml) {
+                tagsElem.classList.add('hide');
+            } else {
+                tagsElem.classList.remove('hide');
+                tagsElem.innerHTML = tagsHtml;
+            }
 
             if (item.IsFolder) {
 


### PR DESCRIPTION
Please note that this code is untested, but there's not much complexity here so as long as my guess about `item.Tags` is correct everything should run fine. :)

I've aimed for displaying the tags directly after the Overview, which is my recommended (and preferred) location, and is also consistent with their location in the Server web-app single-item display. Personally, I'm open to some other locations, but would definitely prefer to have tags displayed somewhere that general area (so, displaying them before the Overview, and after Genres, would be another logical location, though that may run the risk of being confused with Genres).

It might not be a bad idea to eventually add a user setting in the ET client to show or hide Tags (since perhaps some users won't wish to see them displayed), but I'm not familiar enough with the ET architecture yet to do a PR for that.

Let me know if anything else is needed in order to merge this into the core Emby Theater interface.